### PR TITLE
[couchdb] Map Couchdb#save directly to Couchdb#connection.save

### DIFF
--- a/lib/resourceful/engines/couchdb/index.js
+++ b/lib/resourceful/engines/couchdb/index.js
@@ -67,7 +67,7 @@ Couchdb.prototype.put = function (id, doc, callback) {
 };
 
 Couchdb.prototype.save = function () {
-  return this.put.apply(this, arguments);
+  return this.connection.save.apply(this.connection, arguments);
 };
 
 Couchdb.prototype.update = function (id, doc, callback) {


### PR DESCRIPTION
So it uses POST instead of PUT properly on Resource.create. 

This way we avoid the unexpected `TypeError: id must be a string`-errors.

Or do you do this for a certain reason? To me it seems like if my app have to handle id-creation it's not very atomically friendly.
