### PR TITLE
Allow secure connection to CouchDB

### DIFF
--- a/lib/resourceful/engines/couchdb/index.js
+++ b/lib/resourceful/engines/couchdb/index.js
@@ -25,6 +25,7 @@ var Couchdb = exports.Couchdb = function Couchdb(config) {
     port:  config.port || 5984,
     raw:   true,
     cache: false,
+    secure: config.secure,
     auth:  config && config.auth || null
   }).database(config.database || resourceful.env);
   


### PR DESCRIPTION
Cradle supports a `{secure:true}` configuration option that enables HTTPS. This change just lets the CouchDB Engine constructor in Resourceful pass that config option through from the `resourceful.use()` call.

e.g.

```
resourceful.use( 'couchdb', {
    host : "some-server",
    secure : true,
    database : "mydb"
});
```
