### PR TITLE
Adding relationship information onto object so hierarchical functions will work as stated

### DIFF
--- a/lib/resourceful/resource.js
+++ b/lib/resourceful/resource.js
@@ -245,9 +245,17 @@ Resource.destroy = function (id, callback) {
   if (this.schema.properties._id && this.schema.properties._id.sanitize) {
     id = this.schema.properties._id.sanitize(id);
   }
-  
+ 
+  var that = this;
+  function destroy_() {
+    that.get(id, function(err, obj) {
+      if (obj) that._request('destroy', id, obj, callback);
+      else that._request('destroy', id, callback);
+    });
+  }
+
   return id 
-    ? this._request('destroy', id, callback)
+    ? destroy_()
     : callback && callback(new Error('key is undefined'));
 };
 
@@ -458,6 +466,37 @@ function relationship(factory, type, r, options) {
     rfactory.parent(factory);
   } else {
     factory._parents.push(rstringc);
+
+    //
+    // add hook for when deleting a child
+    // 
+
+    factory.before('destroy', function(obj, next) {
+      return obj[rstring](function(err, parentObj) {
+        var key = factory.resource.toLowerCase() + '_ids';
+        if (!parentObj[key]) {
+          // @@TODO
+          return next();
+        }
+        var a = parentObj[key];
+        var index = a.indexOf(obj._id);
+        var toUpdate = {};
+        if (index !== -1) {
+          if (a.length >= index + 2) {
+            toUpdate[key] = a.slice(0, index).concat(a.slice(index + 1, a.length));
+          } else {
+            toUpdate[key] = a.slice(0, index);
+          }
+          return parentObj.update(toUpdate, function(err, result) {
+            // @@TODO
+            return next();
+          });
+        }
+        else {
+          return next();
+        }
+      });
+    });
 
     //
     // Child.byParent(id, callback)


### PR DESCRIPTION
Seems as though this info is not being added onto the parent, so that if you define a parent->child relationship and then create child objects based on an instantiated/saved parent, the parent is never informed of the children and therefore the children can never be retrieved based on the parent id.
