### PR TITLE
emit resource id on destroy hooks

### DIFF
--- a/lib/resourceful/resource.js
+++ b/lib/resourceful/resource.js
@@ -106,6 +106,7 @@ Resource._request = function (/* method, [key, obj], callback */) {
 
   if (key) args.push(key);
   if (obj) args.push(obj.properties ? obj.properties : obj);
+  else obj = key;
 
   this.runBeforeHooks(method, obj, callback, function () {
     args.push(function (e, result) {
@@ -159,7 +160,8 @@ Resource._request = function (/* method, [key, obj], callback */) {
         }
         that.runAfterHooks(method, null, obj, function (e, res) {
           if (e) { that.emit('error', e); }
-          else   { that.emit(method, res || result); }
+          else   { that.emit(method,
+                             method === 'destroy' ? obj : res || result); }
           if (callback) {
             callback(e || null, result);
           }


### PR DESCRIPTION
No info about the object was being emitted when it got destroyed. That's because no `obj` variable is passed to `Resource._request()` when destroy is called.

This patch emits the object key/id.
