### PR TITLE
Creature.get(['a','b','c'],...) throws an error if one of the documents doesn't exist or is deleted

### DIFF
--- a/lib/resourceful/resource.js
+++ b/lib/resourceful/resource.js
@@ -125,7 +125,7 @@ Resource._request = function (/* method, [key, obj], callback */) {
       } else {
         if (Array.isArray(result)) {
           result = result.map(function (r) {
-            return resourceful.instantiate.call(that, r);
+            return r ? resourceful.instantiate.call(that, r) : r;
           });
         } else {
           if (method === 'destroy') {


### PR DESCRIPTION
When fetching a list of documents it seems like more useful behaviour to return the documents that _do_ exist, rather than failing outright. Unsure whether to return the null value in place or remove it from the results, but either way its more useful than before.
