### PR TITLE
fix common.typeOf not properly detecting regexp

### DIFF
--- a/lib/resourceful/common.js
+++ b/lib/resourceful/common.js
@@ -58,7 +58,11 @@ common.typeOf = function (value) {
     return 'array';
   }
   else if (derived === 'object') {
-    return derived ? 'object' : 'null';
+     if (value instanceof RegExp) {
+       return 'regexp';
+     } else {
+       return derived ? 'object' : 'null';
+     }
   }
   else if (derived === 'function') {
     return derived instanceof RegExp ? 'regexp' : 'function';


### PR DESCRIPTION
patch for issue #65

Added a check to see if `value instanceof RegExp` in `common.typeOf` since it appears that the val of `string.pattern(/regexp/)` is an object.

currently `enforceType()` will throw `TypeError` since `typeof(value)` is not a function.
