### PR TITLE
[fix] obj for _request should be pulled from cache and look like normal ...

### DIFF
--- a/lib/resourceful/resource.js
+++ b/lib/resourceful/resource.js
@@ -106,7 +106,7 @@ Resource._request = function (/* method, [key, obj], callback */) {
 
   if (key) args.push(key);
   if (obj) args.push(obj.properties ? obj.properties : obj);
-  else obj = key;
+  else obj = this.connection.cache.get(key) || {_id: key};
 
   this.runBeforeHooks(method, obj, callback, function () {
     args.push(function (e, result) {


### PR DESCRIPTION
Right now we are treating keys as objects if they do not exist in _request, this should really be reconstructed to an object and pulled from cache if possible.
