### PR TITLE
[fix] add a cache to make MemoryStore act more like other stores

### DIFF
--- a/lib/resourceful/engines/memory.js
+++ b/lib/resourceful/engines/memory.js
@@ -9,7 +9,6 @@ var Memory = exports.Memory = function (options) {
   var counter = 0;
   options = options || {};
   this.uri = options.uri;
-
   this.increment = function () {
     return ++counter;
   }
@@ -30,6 +29,7 @@ var Memory = exports.Memory = function (options) {
     this.store = {};
     this.cache = new Cache();
   }
+  this.connection = this;
 };
 
 Memory.prototype.protocol = 'memory';
@@ -76,6 +76,7 @@ Memory.prototype.save = function (key, val, callback) {
   this.request(function () {
     var update = key in this.store;
     this.store[key] = val;
+    this.cache.put(key, val);
     callback(null, resourceful.mixin({ status: update ? 200 : 201 }, val));
   });
 };
@@ -99,6 +100,7 @@ Memory.prototype.get =  function (key, callback) {
 };
 
 Memory.prototype.destroy = function (key, callback) {
+  if (key) this.cache.clear(key);
   this.request(function () {
     delete this.store[key];
     return callback(null, { status: 204 });


### PR DESCRIPTION
This helps with some integration issues when using different stores. The cost of having a cache is minor, but helps with hook object identification. related to https://github.com/flatiron/resourceful/pull/77
