### PR TITLE
[fix] Properly handle options when using an engine

### DIFF
--- a/lib/resourceful/core.js
+++ b/lib/resourceful/core.js
@@ -15,25 +15,28 @@ resourceful.deferredRelationships = {};
 // Select a storage engine
 //
 resourceful.use = function (engine, options) {
-  if (typeof(engine) === "string") {
-    engine = common.capitalize(engine);
+  switch (typeof(engine)) {
+    case "string":
+      engine = common.capitalize(engine);
 
-    if (resourceful.engines[engine]) {
-      this.engine = resourceful.engines[engine];
-    }
-    else {
-      throw new Error("unrecognised engine: " + engine);
-    }
-  }
-  else if (typeof engine === 'function') {
-    this.engine = engine;
-  }
-  else {
-    throw new Error("invalid engine ");
+      if (resourceful.engines[engine]) {
+        this.engine = resourceful.engines[engine];
+      }
+      else {
+        throw new Error("unrecognised engine: " + engine);
+      }
+
+      break;
+    case "function":
+      this.engine = engine;
+      break;
+    default:
+      throw new Error("invalid engine");
   }
 
   this.key = this.engine.key || 'id';
   this.connect(options || {});
+
   return this;
 };
 //
@@ -53,15 +56,21 @@ resourceful.connect = function (/* [uri], [port], [options] */) {
       case 'object': options      = a; break;
     }
   });
-  // Extract the optional 'protocol'
-  // ex: "couchdb://127.0.0.1" would have "database" as protocol.
-  if (m = options.uri && options.uri.match(/^([a-z]+):\/\//)) {
-    protocol = m[1];
-    options.uri = options.uri.replace(protocol + '://', '');
-  }
 
-  if (protocol) {
-    engine = resourceful.engines[common.capitalize(protocol)];
+  // Extract the optional 'protocol' if we haven't already selected an engine
+  // ex: "couchdb://127.0.0.1" would have "couchdb" as it's protocol.
+
+  if (!this.engine) {
+    if (m = options.uri && options.uri.match(/^([a-z]+):\/\//)) {
+      protocol = common.capitalize(m[1]);
+
+      if (resourceful.engines[protocol]) {
+        engine = resourceful.engines[protocol];
+      }
+      else {
+        throw new Error("unrecognised engine: " + engine);
+      }
+    }
   }
   else {
     engine = resourceful.engine || this.engine;

--- a/lib/resourceful/engines/couchdb/index.js
+++ b/lib/resourceful/engines/couchdb/index.js
@@ -14,10 +14,10 @@ var url = require('url'),
 
 var Couchdb = exports.Couchdb = function Couchdb(config) {
   if (config.uri) {
-    var parsed = url.parse('couchdb://' + config.uri);
+    var parsed = url.parse(config.uri);
     config.uri = parsed.hostname;
-    config.port = parseInt(parsed.port, 10);
-    config.database = (parsed.pathname || '').replace(/^\//, '');
+    config.port = parseInt(config.port || parsed.port, 10);
+    config.database = config.database || ((parsed.pathname || '').replace(/\//g, ''));
   }
 
   this.connection = new(cradle.Connection)({

--- a/lib/resourceful/engines/memory.js
+++ b/lib/resourceful/engines/memory.js
@@ -4,7 +4,6 @@ var resourceful = require('../../resourceful'),
 exports.stores = {};
 exports.caches = {};
 
-
 var Memory = exports.Memory = function (options) {
   var counter = 0;
   options = options || {};

--- a/test/resourceful-test.js
+++ b/test/resourceful-test.js
@@ -342,15 +342,85 @@ vows.describe('resourceful').addVows({
     }
   },
   "Engine can be initialised":{
-    "by name": function () {
-      resourceful.use('memory');
-      assert.isFunction(resourceful.engine);
-      assert.equal(resourceful.connection.protocol, 'memory');
+    "by name": {
+      "with options": {
+          topic: function() {
+            return function(r) {
+              assert.equal(r.connection.host, "test");
+              assert.equal(r.connection.port, 123);
+              assert.equal(r.name, "db");
+            }
+          },
+          "uri": function(f) {
+            var r = resourceful.define();
+            r.use("couchdb", { uri: "http://test:123/db" });
+            f(r);
+          },
+          "uri + port": function(f) {
+            var r = resourceful.define();
+            r.use("couchdb", { uri: "http://test/db", port: 123 });
+            f(r);
+          },
+          "uri + port + database": function(f) {
+            var r = resourceful.define();
+            r.use("couchdb", {
+              uri: "http://test",
+              database: "db",
+              port: 123
+            });
+
+            f(r);
+          }
+      },
+      "or without": function() {
+        resourceful.use('couchdb');
+        assert.isFunction(resourceful.engine);
+        assert.equal(resourceful.connection.protocol, 'couchdb');
+
+        resourceful.use('memory');
+        assert.isFunction(resourceful.engine);
+        assert.equal(resourceful.connection.protocol, 'memory');
+      },
     },
-    "by reference": function () {
-      resourceful.use(resourceful.engines.Memory);
-      assert.isFunction(resourceful.engine);
-      assert.equal(resourceful.connection.protocol, 'memory');
+    "by reference": {
+      "with options": {
+          topic: function() {
+            return function(r) {
+              assert.equal(r.connection.host, "test");
+              assert.equal(r.connection.port, 123);
+              assert.equal(r.name, "db");
+            }
+          },
+          "uri": function(f) {
+            var r = resourceful.define();
+            r.use(resourceful.engines.Couchdb, { uri: "http://test:123/db" });
+            f(r);
+          },
+          "uri + port": function(f) {
+            var r = resourceful.define();
+            r.use(resourceful.engines.Couchdb, { uri: "http://test/db", port: 123 });
+            f(r);
+          },
+          "uri + port + database": function(f) {
+            var r = resourceful.define();
+            r.use(resourceful.engines.Couchdb, {
+              uri: "http://test",
+              database: "db",
+              port: 123
+            });
+
+            f(r);
+          }
+      },
+      "or without": function () {
+        resourceful.use(resourceful.engines.Couchdb);
+        assert.isFunction(resourceful.engine);
+        assert.equal(resourceful.connection.protocol, 'couchdb');
+
+        resourceful.use(resourceful.engines.Memory);
+        assert.isFunction(resourceful.engine);
+        assert.equal(resourceful.connection.protocol, 'memory');
+      }
     }
   }
 }).addVows({


### PR DESCRIPTION
- Fixes #45

Added a test to back this up, but `npm test` doesn't seem to work. For what it's worth, the same number of tests are failing before and after this patch.
