### PR TITLE
Added options argument to Resource.timestamps, fixed bug

### DIFF
--- a/lib/resourceful/resource.js
+++ b/lib/resourceful/resource.js
@@ -280,7 +280,7 @@ Resource.save = function (obj, callback) {
       validate = this.prototype.validate(obj, this.schema);
 
   if (!validate.valid) {
-    var e = { validate: validate, value: instance, schema: that.schema };
+    var e = { validate: validate, value: obj, schema: this.schema };
     return callback && callback(e);
   }
 


### PR DESCRIPTION
This partly fixes #84, the only thing that needs to be done is to actually update `atime`.
