### PR TITLE
Issue #121: Prevent attribute from being set as property on resource if ...

### DIFF
--- a/lib/resourceful/core.js
+++ b/lib/resourceful/core.js
@@ -116,7 +116,9 @@ resourceful.define = function (name, definition) {
 
     if (attrs) {
       Object.keys(attrs).forEach(function (k) {
-        self._properties[k] = attrs[k];
+        if (k in Factory.properties || k === '_rev') {
+          self._properties[k] = attrs[k];
+        }
       });
     }
 

--- a/test/hooks-sync-test.js
+++ b/test/hooks-sync-test.js
@@ -7,6 +7,7 @@ vows.describe('resourceful/hooks/sync').addBatch({
     topic: function () {
       return resourceful.define('Resource', function () {
         this.property('name');
+        this.property('counter', Number);
       });
     },
     "synchronous 'before' hooks on `save`": {
@@ -41,6 +42,7 @@ vows.describe('resourceful/hooks/sync').addBatch({
     topic: function () {
       return resourceful.define('Resource2', function () {
         this.property('name');
+        this.property('counter', Number);
       });
     },
     "synchronous 'after' hooks on `save`": {
@@ -85,6 +87,7 @@ vows.describe('resourceful/hooks/sync').addBatch({
     topic: function () {
       return resourceful.define('Resource3', function () {
         this.property('title');
+        this.property('counter', Number);
       });
     },
     "with synchronous 'before' hooks on `create`": {
@@ -119,6 +122,7 @@ vows.describe('resourceful/hooks/sync').addBatch({
     topic: function () {
       return resourceful.define('Resource4', function () {
         this.property('title');
+        this.property('counter', Number);
       });
     },
     "with synchronous 'after' hooks on `create`": {

--- a/test/resourceful-test.js
+++ b/test/resourceful-test.js
@@ -138,7 +138,14 @@ vows.describe('resourceful').addVows({
         assert.include(r, 'kind');
         assert.isString(r.kind);
       }
-    }
+    }, "When instantiated with an attribute that's not a defined property": {
+        topic: function (R) {
+          return new(R)({ title: 'The Great Gatsby', kind: 'Classic Novels', author: 'F. Scott Fitzgerald' });
+        },
+        "should return `undefined` when that attribute is accessed": function(r) {
+          assert.isUndefined(r.author);
+        }
+    },
   },
   "A Resource with duplicate properties": {
     topic: function () {


### PR DESCRIPTION
...property is not defined

Per my comments on the issue, I'm not sure whether this behavior is desired or unintentional. The fix was easy though -- I just added a guard in the constructor that only sets `_properties[key]` if key is in Factory.properties, with an exception for the `_rev` attribute.

A few tests were (ab)using the ability to save arbitrary values so I defined those explicitly to get them working. This illustrates that the new behavior is backwards incompatible and could break for others who are setting and saving arbitrary attributes in this manner.
