### PR TITLE
engine priority

### DIFF
--- a/lib/resourceful/core.js
+++ b/lib/resourceful/core.js
@@ -71,7 +71,7 @@ resourceful.connect = function (/* [uri], [port], [options] */) {
     }
   }
   else {
-    engine = resourceful.engine || this.engine;
+    engine = this.engine || resourceful.engine;
   }
 
   this.connection = new(engine)(options);


### PR DESCRIPTION
The tests pass either way so its not clear what is supposed to be the correct behaviour but it makes sense that the resource specified engine would take priority over the global setting. 
