### PR TITLE
added db_options to config objetc

### DIFF
--- a/lib/resourceful/engines/mongodb.js
+++ b/lib/resourceful/engines/mongodb.js
@@ -20,7 +20,7 @@ var Mongodb = exports.Mongodb = function Mongodb (config) {
 
   this.db = new Db(config.database || resourceful.env || 'test',
     new Server(config.host || config.uri || '127.0.0.1',
-      config.port || 27017));
+      config.port || 27017), config.db_options);
 
   this.collection = config.collection || 'resourceful';
 

--- a/test/engines/mongodb.js
+++ b/test/engines/mongodb.js
@@ -10,7 +10,8 @@ engine.options = {
   database: 'test',
   host: '127.0.0.1',
   port: 27017,
-  collection: 'resourceful'
+  collection: 'resourceful',
+  db_options: {safe:true}
 };
 
 engine.load = function (resourceful, data, callback) {


### PR DESCRIPTION
Hi Folks,

It seems that some new release of mongo driver is nagging about the db_options not being passed. I just added a monkey patch so we can pass db_options as required. feel free to dismiss it if not aligned to restful code organization.

I also noticed that running the tests in mongodb-support-2 does not pass. Since the error is not related to the mongodb engine, I'm assuming this is solved in master.

Is there any plans of merging this branch into master?

Cheers,

Eric
