### PR TITLE
Prefix view names with resource name to prevent conflicts

### DIFF
--- a/lib/resourceful/engines/couchdb/view.js
+++ b/lib/resourceful/engines/couchdb/view.js
@@ -9,7 +9,8 @@ exports.filter = function (name /* [options], filter */) {
   var args = Array.prototype.slice.call(arguments),
       R = this,
       filter = args.pop(),
-      options = (typeof(args[args.length - 1]) === 'object') && args.pop();
+      options = (typeof(args[args.length - 1]) === 'object') && args.pop(),
+      viewName = R._resource + '_' + name;
 
   if (R._design && R._design._rev) {
     throw new(Error)("Cannot call 'filter' after design has been saved to database");
@@ -26,11 +27,11 @@ exports.filter = function (name /* [options], filter */) {
         filter[key] = filter[key].toString().replace(/\n|\r/g, '')
                                             .replace(/\s+/g, ' ');
       });
-      R.views[name] = filter;
+      R.views[viewName] = filter;
     // Here, we treat the filter as a sub-object which must be matched
     // in the document to pass through.
     } else {
-      R.views[name] = resourceful.render({
+      R.views[viewName] = resourceful.render({
         map: function (doc) {
           var object = $object;
           if (doc.resource === $resource) {
@@ -45,7 +46,7 @@ exports.filter = function (name /* [options], filter */) {
       }, { object: filter, resource: JSON.stringify(R.resource) });
     }
   } else if (typeof(filter) === 'function') {
-    R.views[name] = resourceful.render({
+    R.views[viewName] = resourceful.render({
       map: function (doc) {
         if (doc.resource === $resource) {
             emit($key, doc);


### PR DESCRIPTION
If two resources both define a view named "all" (critical for CouchDB efficiency, overriding the default .all() implementation), the last defined resource will override the definition of the "all" view.

Prefix the view name with the resource name to prevent such collisions.
